### PR TITLE
fix: Bug fixes - DST, retry backoff, null UserId, version increment, memory leak (#2)

### DIFF
--- a/src/DayTrace.Api/BackgroundServices/DailyReminderService.cs
+++ b/src/DayTrace.Api/BackgroundServices/DailyReminderService.cs
@@ -116,10 +116,14 @@ public class DailyReminderService : BackgroundService
         // Handle DST: spring-forward (time doesn't exist) → shift to next valid time
         if (tz.IsInvalidTime(reminderLocalDateTime))
         {
-            // Spring-forward: shift forward by the adjustment gap
-            var adjustedUtc = TimeZoneInfo.ConvertTimeToUtc(
-                reminderLocalDateTime.AddHours(1).Date.AddHours(reminderLocalDateTime.Hour + 1), tz);
-            reminderLocalDateTime = TimeZoneInfo.ConvertTimeFromUtc(adjustedUtc, tz);
+            // Spring-forward: advance past the DST gap using the timezone's actual daylight delta
+            var dstDelta = tz.GetAdjustmentRules()
+                .Where(r => r.DateStart.Year <= reminderLocalDateTime.Year &&
+                            r.DateEnd.Year >= reminderLocalDateTime.Year)
+                .Select(r => r.DaylightDelta)
+                .DefaultIfEmpty(TimeSpan.FromHours(1))
+                .First();
+            reminderLocalDateTime = reminderLocalDateTime.Add(dstDelta);
             _logger.LogInformation(
                 "DailyReminder: DST spring-forward adjustment for user_id={UserId}, shifted to {AdjustedTime}",
                 user.Id, reminderLocalDateTime);

--- a/src/DayTrace.Api/BackgroundServices/DeliveryRetryService.cs
+++ b/src/DayTrace.Api/BackgroundServices/DeliveryRetryService.cs
@@ -79,8 +79,10 @@ public class DeliveryRetryService : BackgroundService
                 if (!isPendingAdminBroadcast)
                 {
                     // Check backoff: exponential — 30s * 2^(attempt_number-1)
+                    // Calculate from LastAttemptAt (most recent attempt) or CreatedAt for first retry
                     var backoff = TimeSpan.FromSeconds(30 * Math.Pow(2, attempt.AttemptNumber - 1));
-                    var backoffReady = attempt.CreatedAt.Add(backoff);
+                    var backoffBase = attempt.LastAttemptAt ?? attempt.CreatedAt;
+                    var backoffReady = backoffBase.Add(backoff);
                     if (DateTime.UtcNow < backoffReady) continue;
                 }
 
@@ -106,6 +108,9 @@ public class DeliveryRetryService : BackgroundService
                 {
                     attempt.AttemptNumber += 1;
                 }
+
+                // Track when this attempt is being processed
+                attempt.LastAttemptAt = DateTime.UtcNow;
 
                 // Resolve period name for period-related deliveries
                 var periodName = await ResolvePeriodNameAsync(attempt, scope, ct);
@@ -205,14 +210,23 @@ public class DeliveryRetryService : BackgroundService
 
     /// <summary>
     /// Resolves a human-readable period name for period-related deliveries.
+    /// Looks up the referenced Summary to get the PeriodType and maps it to a display name.
     /// </summary>
-    private static Task<string> ResolvePeriodNameAsync(
+    private static async Task<string> ResolvePeriodNameAsync(
         DeliveryAttempt attempt, IServiceScope scope, CancellationToken ct)
     {
         if (attempt.DeliveryType is not ("soft_reminder" or "summary_notification"))
-            return Task.FromResult("");
+            return "";
 
-        return Task.FromResult("за период");
+        if (attempt.ReferenceId.HasValue)
+        {
+            var summaryRepo = scope.ServiceProvider.GetRequiredService<ISummaryRepository>();
+            var summary = await summaryRepo.GetByIdAsync(attempt.ReferenceId.Value, ct);
+            if (summary != null)
+                return GetPeriodDisplayName(summary.PeriodType);
+        }
+
+        return GetPeriodDisplayName(string.Empty);
     }
 
     private static string GetPeriodDisplayName(string periodType) => periodType switch

--- a/src/DayTrace.Api/Controllers/AuthController.cs
+++ b/src/DayTrace.Api/Controllers/AuthController.cs
@@ -55,13 +55,19 @@ public class AuthController : ControllerBase
                 request.Timezone,
                 ct);
 
-            // Replay case: User may be null (cached token returned without re-loading user)
+            if (result.User == null)
+            {
+                _logger.LogWarning("Telegram auth: authentication succeeded but User is null for token prefix={TokenPrefix}",
+                    result.Token.Length > 8 ? result.Token[..8] + "..." : result.Token);
+                return Unauthorized(new { error = "auth_incomplete", message = "Authentication succeeded but user data is unavailable" });
+            }
+
             return Ok(new TelegramAuthResponse
             {
                 Token = result.Token,
-                UserId = result.User?.Id ?? 0,
+                UserId = result.User.Id,
                 IsNew = result.IsNew,
-                Timezone = result.User?.Settings?.Timezone ?? "Europe/Moscow"
+                Timezone = result.User.Settings?.Timezone ?? "Europe/Moscow"
             });
         }
         catch (AuthenticationException ex)

--- a/src/DayTrace.Bot/Handlers/BotUpdateHandler.cs
+++ b/src/DayTrace.Bot/Handlers/BotUpdateHandler.cs
@@ -46,6 +46,9 @@ public class BotUpdateHandler
     {
         _logger.LogInformation("Received update {UpdateId} of type {UpdateType}", update.Id, update.Type);
 
+        // Periodically clean stale dedup entries on every update to prevent unbounded growth
+        CleanRecentCallbacks();
+
         try
         {
             var handler = update switch
@@ -205,9 +208,6 @@ public class BotUpdateHandler
         }
         RecentCallbacks[dedupeKey] = DateTime.UtcNow;
 
-        // Clean old entries periodically
-        CleanRecentCallbacks();
-
         // Acknowledge the callback
         await _botClient.AnswerCallbackQuery(callbackQuery.Id, cancellationToken: ct);
 
@@ -238,7 +238,8 @@ public class BotUpdateHandler
 
     private static void CleanRecentCallbacks()
     {
-        var cutoff = DateTime.UtcNow.AddSeconds(-10);
+        // Remove entries older than 5 minutes — far beyond the 3-second dedup window
+        var cutoff = DateTime.UtcNow.AddMinutes(-5);
         foreach (var key in RecentCallbacks.Keys.ToArray())
         {
             if (RecentCallbacks.TryGetValue(key, out var ts) && ts < cutoff)

--- a/src/DayTrace.Domain/Entities/DeliveryAttempt.cs
+++ b/src/DayTrace.Domain/Entities/DeliveryAttempt.cs
@@ -12,6 +12,7 @@ public class DeliveryAttempt
     public long? TelegramMessageId { get; set; }
     public DateTime? ScheduledAt { get; set; }
     public DateTime? SentAt { get; set; }
+    public DateTime? LastAttemptAt { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     public User? User { get; set; }

--- a/src/DayTrace.Domain/Interfaces/ISummaryRepository.cs
+++ b/src/DayTrace.Domain/Interfaces/ISummaryRepository.cs
@@ -5,6 +5,11 @@ namespace DayTrace.Domain.Interfaces;
 public interface ISummaryRepository
 {
     /// <summary>
+    /// Gets a summary by its primary key.
+    /// </summary>
+    Task<Summary?> GetByIdAsync(long id, CancellationToken ct = default);
+
+    /// <summary>
     /// Gets a summary by user/period unique key.
     /// </summary>
     Task<Summary?> GetAsync(long userId, string periodType, DateOnly periodStart, DateOnly periodEnd, CancellationToken ct = default);

--- a/src/DayTrace.Domain/Services/HighlightService.cs
+++ b/src/DayTrace.Domain/Services/HighlightService.cs
@@ -98,6 +98,7 @@ public class HighlightService
             summary.HighlightEventId = eventId;
             summary.Status = "generated";
             summary.LastGeneratedAt = DateTime.UtcNow;
+            summary.Version += 1;
             await _summaryRepo.UpdateAsync(summary, ct);
         }
 

--- a/src/DayTrace.Infrastructure/Data/DayTraceDbContext.cs
+++ b/src/DayTrace.Infrastructure/Data/DayTraceDbContext.cs
@@ -158,6 +158,7 @@ public class DayTraceDbContext : DbContext
             entity.Property(e => e.TelegramMessageId).HasColumnName("telegram_message_id");
             entity.Property(e => e.ScheduledAt).HasColumnName("scheduled_at");
             entity.Property(e => e.SentAt).HasColumnName("sent_at");
+            entity.Property(e => e.LastAttemptAt).HasColumnName("last_attempt_at");
             entity.Property(e => e.CreatedAt).HasColumnName("created_at");
 
             entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Cascade);

--- a/src/DayTrace.Infrastructure/Data/Migrations/20260226031927_AddDeliveryAttemptLastAttemptAt.Designer.cs
+++ b/src/DayTrace.Infrastructure/Data/Migrations/20260226031927_AddDeliveryAttemptLastAttemptAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DayTrace.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DayTrace.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(DayTraceDbContext))]
-    partial class DayTraceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260226031927_AddDeliveryAttemptLastAttemptAt")]
+    partial class AddDeliveryAttemptLastAttemptAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DayTrace.Infrastructure/Data/Migrations/20260226031927_AddDeliveryAttemptLastAttemptAt.cs
+++ b/src/DayTrace.Infrastructure/Data/Migrations/20260226031927_AddDeliveryAttemptLastAttemptAt.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DayTrace.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeliveryAttemptLastAttemptAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_attempt_at",
+                table: "delivery_attempts",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_attempt_at",
+                table: "delivery_attempts");
+        }
+    }
+}

--- a/src/DayTrace.Infrastructure/Repositories/SummaryRepository.cs
+++ b/src/DayTrace.Infrastructure/Repositories/SummaryRepository.cs
@@ -15,6 +15,11 @@ public class SummaryRepository : ISummaryRepository
         _context = context;
     }
 
+    public async Task<Summary?> GetByIdAsync(long id, CancellationToken ct = default)
+    {
+        return await _context.Summaries.FindAsync(new object[] { id }, ct);
+    }
+
     public async Task<Summary?> GetAsync(
         long userId, string periodType, DateOnly periodStart, DateOnly periodEnd,
         CancellationToken ct = default)


### PR DESCRIPTION
## Проблема
Несколько багов в бизнес-логике: некорректная обработка DST, backoff от CreatedAt вместо LastAttemptAt, UserId=0 при null User, отсутствие инкремента Version, утечка памяти в RecentCallbacks.

## Решение
- Исправлена логика spring-forward DST в DailyReminderService
- Backoff в DeliveryRetryService считается от времени последней попытки
- AuthController возвращает явную ошибку при null User вместо UserId=0
- HighlightService инкрементирует Version при обновлении Summary
- BotUpdateHandler очищает устаревшие записи из RecentCallbacks
- GetPeriodDisplayName подключен в ResolvePeriodNameAsync

Closes #2