### PR TITLE
fix: remove wildcard CORS policy, require explicit ALLOWED_ORIGINS (#7)

### DIFF
--- a/src/DayTrace.Api/Program.cs
+++ b/src/DayTrace.Api/Program.cs
@@ -31,22 +31,19 @@ try
         .AddDbContextCheck<DayTraceDbContext>("postgresql");
 
     // CORS
-    var allowedOrigins = builder.Configuration.GetValue<string>("ALLOWED_ORIGINS") ?? "*";
+    var allowedOrigins = builder.Configuration.GetValue<string>("ALLOWED_ORIGINS");
+    if (string.IsNullOrWhiteSpace(allowedOrigins))
+        throw new InvalidOperationException("ALLOWED_ORIGINS must be configured explicitly. Set it as a comma-separated list of allowed origins.");
+
     builder.Services.AddCors(options =>
     {
         options.AddDefaultPolicy(policy =>
         {
-            if (allowedOrigins == "*")
-            {
-                policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader();
-            }
-            else
-            {
-                policy.WithOrigins(allowedOrigins.Split(',', StringSplitOptions.RemoveEmptyEntries))
-                      .AllowAnyMethod()
-                      .AllowAnyHeader()
-                      .AllowCredentials();
-            }
+            var origins = allowedOrigins.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            policy.WithOrigins(origins)
+                  .AllowAnyMethod()
+                  .AllowAnyHeader()
+                  .AllowCredentials();
         });
     });
 

--- a/src/DayTrace.Api/appsettings.Development.json
+++ b/src/DayTrace.Api/appsettings.Development.json
@@ -2,7 +2,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5433;Database=daytrace;Username=daytrace;Password=daytrace_dev"
   },
-  "ALLOWED_ORIGINS": "*",
+  "ALLOWED_ORIGINS": "http://localhost:3000,http://localhost:5173",
   "Logging": {
     "LogLevel": {
       "Default": "Debug"

--- a/src/DayTrace.Api/appsettings.json
+++ b/src/DayTrace.Api/appsettings.json
@@ -2,7 +2,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5433;Database=daytrace;Username=daytrace;Password=daytrace_dev"
   },
-  "ALLOWED_ORIGINS": "*",
+  "ALLOWED_ORIGINS": "",
   "TelegramBot": {
     "BotToken": "",
     "WebhookSecretToken": "",

--- a/tests/DayTrace.Tests/Integration/DayTraceWebFactory.cs
+++ b/tests/DayTrace.Tests/Integration/DayTraceWebFactory.cs
@@ -7,6 +7,7 @@ using DayTrace.Infrastructure.Data;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Telegram.Bot;
@@ -28,6 +29,8 @@ public class DayTraceWebFactory : WebApplicationFactory<Program>
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
+
+        builder.UseSetting("ALLOWED_ORIGINS", "http://localhost");
 
         builder.ConfigureServices(services =>
         {


### PR DESCRIPTION
## Проблема
CORS-политика по умолчанию использовала AllowAnyOrigin() если ALLOWED_ORIGINS не настроен. Это позволяло любому сайту делать cross-origin запросы к API.

## Решение
- Удалён wildcard `"ALLOWED_ORIGINS": "*"` из appsettings.json
- Fallback изменён: если ALLOWED_ORIGINS не задан — выбрасывается InvalidOperationException
- CORS конфигурируется только через явный список origin
- appsettings.Development.json обновлён с localhost origins для разработки
- Тесты обновлены: добавлен ALLOWED_ORIGINS в тестовую конфигурацию

Closes #7