### PR TITLE
fix: strict CORS validation + integration tests

### DIFF
--- a/src/DayTrace.Api/Program.cs
+++ b/src/DayTrace.Api/Program.cs
@@ -35,12 +35,17 @@ try
     if (string.IsNullOrWhiteSpace(allowedOrigins))
         throw new InvalidOperationException("ALLOWED_ORIGINS must be configured explicitly. Set it as a comma-separated list of allowed origins.");
 
+    var parsedOrigins = allowedOrigins.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    if (parsedOrigins.Length == 0)
+        throw new InvalidOperationException("ALLOWED_ORIGINS must contain at least one valid origin.");
+    if (parsedOrigins.Any(o => o == "*"))
+        throw new InvalidOperationException("Wildcard '*' is not allowed in ALLOWED_ORIGINS. Specify explicit origins.");
+
     builder.Services.AddCors(options =>
     {
         options.AddDefaultPolicy(policy =>
         {
-            var origins = allowedOrigins.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            policy.WithOrigins(origins)
+            policy.WithOrigins(parsedOrigins)
                   .AllowAnyMethod()
                   .AllowAnyHeader()
                   .AllowCredentials();

--- a/tests/DayTrace.Tests/Integration/CorsTests.cs
+++ b/tests/DayTrace.Tests/Integration/CorsTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace DayTrace.Tests.Integration;
+
+[Collection("Postgres")]
+public class CorsTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _pg;
+    private DayTraceWebFactory _factory = null!;
+
+    public CorsTests(PostgresFixture pg) => _pg = pg;
+
+    public async Task InitializeAsync()
+    {
+        _factory = new DayTraceWebFactory(_pg.ConnectionString);
+        await _factory.CleanDatabaseAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        _factory?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Cors_AllowedOrigin_ReturnsHeaders()
+    {
+        var client = _factory.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/health");
+        request.Headers.Add("Origin", "http://localhost");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Headers.Contains("Access-Control-Allow-Origin"));
+        Assert.Equal("http://localhost", response.Headers.GetValues("Access-Control-Allow-Origin").First());
+    }
+
+    [Fact]
+    public async Task Cors_DisallowedOrigin_NoHeaders()
+    {
+        var client = _factory.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/health");
+        request.Headers.Add("Origin", "http://evil.example.com");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    [Fact]
+    public async Task Cors_Preflight_AllowedOrigin_Returns200()
+    {
+        var client = _factory.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Options, "/api/events");
+        request.Headers.Add("Origin", "http://localhost");
+        request.Headers.Add("Access-Control-Request-Method", "POST");
+        request.Headers.Add("Access-Control-Request-Headers", "Content-Type, Authorization");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.True(response.Headers.Contains("Access-Control-Allow-Origin"));
+        Assert.Equal("http://localhost", response.Headers.GetValues("Access-Control-Allow-Origin").First());
+        Assert.True(response.Headers.Contains("Access-Control-Allow-Credentials"));
+        Assert.Equal("true", response.Headers.GetValues("Access-Control-Allow-Credentials").First());
+    }
+
+    [Fact]
+    public async Task Cors_Preflight_DisallowedOrigin_NoAllowHeaders()
+    {
+        var client = _factory.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Options, "/api/events");
+        request.Headers.Add("Origin", "http://evil.example.com");
+        request.Headers.Add("Access-Control-Request-Method", "POST");
+
+        var response = await client.SendAsync(request);
+
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    [Fact]
+    public void MissingAllowedOrigins_ThrowsOnStartup()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var factory = new WebApplicationFactory<Program>()
+                .WithWebHostBuilder(builder =>
+                {
+                    builder.UseEnvironment("Testing");
+                    builder.UseSetting("ALLOWED_ORIGINS", "");
+                    builder.ConfigureServices(services => { });
+                });
+            // Force host creation
+            _ = factory.Server;
+        });
+    }
+
+    [Fact]
+    public void WildcardAllowedOrigins_ThrowsOnStartup()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var factory = new WebApplicationFactory<Program>()
+                .WithWebHostBuilder(builder =>
+                {
+                    builder.UseEnvironment("Testing");
+                    builder.UseSetting("ALLOWED_ORIGINS", "http://localhost,*");
+                    builder.ConfigureServices(services => { });
+                });
+            _ = factory.Server;
+        });
+    }
+}

--- a/tests/DayTrace.Tests/Integration/DayTraceWebFactory.cs
+++ b/tests/DayTrace.Tests/Integration/DayTraceWebFactory.cs
@@ -7,7 +7,6 @@ using DayTrace.Infrastructure.Data;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Telegram.Bot;


### PR DESCRIPTION
## Изменения

Исправления по результатам код-ревью PR #8 (GPT 5.3 Codex):

### Валидация (Program.cs)
- Явный запрет wildcard `*` в `ALLOWED_ORIGINS` → `InvalidOperationException`
- Проверка пустого массива origins после split → `InvalidOperationException`
- Origins парсятся один раз при старте (вынесено из lambda)

### Тесты (CorsTests.cs) — 6 тестов
- ✅ Allowed origin → возвращает `Access-Control-Allow-Origin`
- ✅ Disallowed origin → нет CORS-заголовков
- ✅ Preflight allowed → 204 + credentials
- ✅ Preflight disallowed → нет allow-заголовков
- ✅ Пустой `ALLOWED_ORIGINS` → `InvalidOperationException` на старте
- ✅ Wildcard в `ALLOWED_ORIGINS` → `InvalidOperationException` на старте

### Cleanup
- Убран неиспользуемый `using Microsoft.Extensions.Configuration` в `DayTraceWebFactory.cs`

Все 6 тестов проходят.